### PR TITLE
minor refactoring according to best practices

### DIFF
--- a/compressor.go
+++ b/compressor.go
@@ -1,23 +1,19 @@
-package messagecompression
+package compressor
 
 import (
 	"errors"
+
+	"github.com/open-cluster-management/hub-of-hubs-message-compression/compressors"
 )
 
 var errCompressorTypeNotFound = errors.New("compressor type not supported")
 
 // NewCompressor returns a compressor instance that corresponds to the given CompressorType.
-func NewCompressor(compressorType CompressorType) (Compressor, error) {
+func NewCompressor(compressorType CompressType) (compressors.Compressor, error) {
 	createCompressorFunc, found := compressorsMap[compressorType]
 	if !found {
 		return nil, errCompressorTypeNotFound
 	}
 
 	return createCompressorFunc(), nil
-}
-
-// Compressor declares the functionality provided by the different compression logics supported.
-type Compressor interface {
-	Compress([]byte) ([]byte, error)
-	Decompress([]byte) ([]byte, error)
 }

--- a/compressor_types.go
+++ b/compressor_types.go
@@ -1,19 +1,20 @@
-package messagecompression
+package compressor
 
-import supportedcompressors "github.com/open-cluster-management/hub-of-hubs-message-compression/supported-compressors"
+import (
+	"github.com/open-cluster-management/hub-of-hubs-message-compression/compressors"
+	"github.com/open-cluster-management/hub-of-hubs-message-compression/compressors/gzip"
+)
 
-// CompressorType is the type of supported compressors.
+// CompressType is the compressing supported types.
 //
 // Supported types: GZip.
-type CompressorType string
+type CompressType string
 
 const (
 	// GZip is used to create a gzip-based Compressor.
-	GZip CompressorType = "gzip"
+	GZip CompressType = "gzip"
 )
 
-var compressorsMap = map[CompressorType]func() Compressor{
-	GZip: func() Compressor {
-		return supportedcompressors.CreateGzipCompressor()
-	},
+var compressorsMap = map[CompressType]func() compressors.Compressor{
+	GZip: gzip.NewGzipCompressor,
 }

--- a/compressors/compressor.go
+++ b/compressors/compressor.go
@@ -1,0 +1,7 @@
+package compressors
+
+// Compressor declares the functionality provided by the different compression logics supported.
+type Compressor interface {
+	Compress([]byte) ([]byte, error)
+	Decompress([]byte) ([]byte, error)
+}

--- a/compressors/gzip/gzip_compressor.go
+++ b/compressors/gzip/gzip_compressor.go
@@ -20,7 +20,7 @@ func NewGzipCompressor() compressors.Compressor {
 type CompressorGZip struct{}
 
 // Compress compresses a slice of bytes using gzip lib.
-func (gzc *CompressorGZip) Compress(data []byte) ([]byte, error) {
+func (compressor *CompressorGZip) Compress(data []byte) ([]byte, error) {
 	var buf bytes.Buffer
 
 	gw, err := gzip.NewWriterLevel(&buf, gzip.BestSpeed)
@@ -36,7 +36,7 @@ func (gzc *CompressorGZip) Compress(data []byte) ([]byte, error) {
 }
 
 // Decompress decompresses a slice of gzip-compressed bytes using gzip lib.
-func (gzc *CompressorGZip) Decompress(compressedData []byte) ([]byte, error) {
+func (compressor *CompressorGZip) Decompress(compressedData []byte) ([]byte, error) {
 	// create a reader for the gzipped data
 	gr, err := gzip.NewReader(bytes.NewBuffer(compressedData))
 	if err != nil {

--- a/compressors/gzip/gzip_compressor.go
+++ b/compressors/gzip/gzip_compressor.go
@@ -1,24 +1,26 @@
-package supportedcompressors
+package gzip
 
 import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
 	"io/ioutil"
+
+	"github.com/open-cluster-management/hub-of-hubs-message-compression/compressors"
 )
-
-// CreateGzipCompressor returns a new instance of gzip-based compressor.
-func CreateGzipCompressor() *GZipCompressor {
-	return &GZipCompressor{}
-}
-
-// GZipCompressor implements Compressor with gzip-based logic.
-type GZipCompressor struct{}
 
 const gzipCompressorErrorString = "gzip compressor error"
 
+// NewGzipCompressor returns a new instance of gzip-based compressor.
+func NewGzipCompressor() compressors.Compressor {
+	return &CompressorGZip{}
+}
+
+// CompressorGZip implements Compressor with gzip-based logic.
+type CompressorGZip struct{}
+
 // Compress compresses a slice of bytes using gzip lib.
-func (gzc *GZipCompressor) Compress(data []byte) ([]byte, error) {
+func (gzc *CompressorGZip) Compress(data []byte) ([]byte, error) {
 	var buf bytes.Buffer
 
 	gw, err := gzip.NewWriterLevel(&buf, gzip.BestSpeed)
@@ -34,9 +36,9 @@ func (gzc *GZipCompressor) Compress(data []byte) ([]byte, error) {
 }
 
 // Decompress decompresses a slice of gzip-compressed bytes using gzip lib.
-func (gzc *GZipCompressor) Decompress(compressed []byte) ([]byte, error) {
-	// Write gzipped data to the client
-	gr, err := gzip.NewReader(bytes.NewBuffer(compressed))
+func (gzc *CompressorGZip) Decompress(compressedData []byte) ([]byte, error) {
+	// create a reader for the gzipped data
+	gr, err := gzip.NewReader(bytes.NewBuffer(compressedData))
 	if err != nil {
 		return nil, fmt.Errorf("%s - %w", gzipCompressorErrorString, err)
 	}


### PR DESCRIPTION
I modified to repo structure a bit according to best practices.
that is - the interface Compressor is inside the directory compressors, and each compressor that implements the interface is inside it's own directory under compressors (same as we have transport dir with interface and inside we have kafka/sync-service implementation or alternatively same as we have db and then postgresql).

in addition I changed the package names to be easier and straight forward.